### PR TITLE
Remove White Border Around Profile Pictures

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -136,3 +136,7 @@ body {
 ._6ynl {
   border-bottom: 1px solid rgba(255, 255, 255, 0.05) !important;
 }
+
+._7q1i, ._7q0v {
+  border: 0 !important;
+}

--- a/style.scss
+++ b/style.scss
@@ -196,6 +196,7 @@ $typingIndicatorContainer: "._4gd0";
 }
 
 // Borders
+$chatBubbles: "._7q1i, ._7q0v";
 $infoPanelContainer: "._4_j5";
 $infoPanelDivBorder: "._1li-";
 $conversationTitleContainer: "._6ynl";
@@ -214,4 +215,8 @@ $replyToMessageSection: "._67tu";
 
 #{$conversationTitleContainer} {
   border-bottom: $borderStyle
+}
+
+#{$chatBubbles}{
+  border:0 !important;
 }


### PR DESCRIPTION
Goes from this:
![image](https://user-images.githubusercontent.com/63570267/98073162-b2fda780-1e35-11eb-8f52-a86cfa2c39a0.png)
Into this:
![image](https://user-images.githubusercontent.com/63570267/98073178-bc870f80-1e35-11eb-93e1-239330f7771b.png)

Works for both the sidebar and the conversation title box.