### PR TITLE
Update class name of icons

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -2,10 +2,10 @@ svg:not([fill]):not(.crt8y2ji) path:not([fill]) {
   fill: var(--primary-icon) !important;
 }
 
-.moj8do2t {
+.x1p6odiv {
   color: var(--always-white) !important;
 }
-.moj8do2t path[fill] {
+.x1p6odiv path[fill] {
   fill: var(--primary-icon) !important;
 }
 

--- a/style.scss
+++ b/style.scss
@@ -6,7 +6,7 @@ svg:not([fill]):not(.crt8y2ji) path:not([fill]) {
 
 // Many icons (e.g. Create Room, Edit Nicknames) use this class that sets the color
 // to --always-black. Overwrite them and use light icons instead.
-.moj8do2t {
+.x1p6odiv {
     color: var(--always-white) !important;
 
     // Some icons specify their color via the path fill attribute, which overrides any


### PR DESCRIPTION
Turns all the icons from the "Privacy and Support" section to the right color. Also fixes other icons ("Search in conversation", "Video call", etc)